### PR TITLE
Correct Upgrade Command

### DIFF
--- a/docs/prologue/upgrade-guide/3.x.md
+++ b/docs/prologue/upgrade-guide/3.x.md
@@ -24,7 +24,7 @@
 For your convenience, we have created an upgrade console command:
 
 ```bash
-php artisan actions:upgrade
+php artisan migrate:actions:upgrade
 ```
 
 It will do the following:


### PR DESCRIPTION
I was running through the upgrade from 2.x to 3.x and discovered that the upgrade command was not correct.

The 3.x version still uses the `migrate` namespace, so the correct command is:
```sh
php artisan migrate:actions:upgrade
```
