### PR TITLE
Fixed bug when use isolate option

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,6 +1,6 @@
 name: phpunit
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
     build:

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -25,11 +25,7 @@ trait Isolatable
 
     protected function getIsolateOption(): bool|int
     {
-        if ($code = $this->option(Options::ISOLATED)) {
-            return intval($code);
-        }
-
-        return false;
+        return $this->hasIsolateOption() ? (int) $this->option(Options::ISOLATED) : false;
     }
 
     protected function hasIsolateOption(): bool

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -25,7 +25,11 @@ trait Isolatable
 
     protected function getIsolateOption(): bool|int
     {
-        return $this->hasIsolateOption() && $this->option(Options::ISOLATED);
+        if ($code = $this->option(Options::ISOLATED)) {
+            return intval($code);
+        }
+
+        return false;
     }
 
     protected function hasIsolateOption(): bool

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -25,7 +25,7 @@ trait Isolatable
 
     protected function getIsolateOption(): bool|int
     {
-        return $this->hasIsolateOption() ? $this->option(Options::ISOLATED) : false;
+        return $this->hasIsolateOption() && $this->option(Options::ISOLATED);
     }
 
     protected function hasIsolateOption(): bool


### PR DESCRIPTION
Hello,
I have a bug when I use isolate option `DragonCode\LaravelActions\Console\Command::getIsolateOption(): Return value must be of type int|bool, string returned`